### PR TITLE
chore(config): 更新项目配置和Docker镜像设置

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -9,7 +9,7 @@ FrameworkJava 使用 **Nacos** 作为配置中心，实现配置的统一管理�
 配置文件命名格式：`{服务名}-{环境}.yaml`
 
 示例：
-- `zmbdp-gateway-service-dev.yaml`
+- `zmbdp-gateway-dev.yaml`
 - `zmbdp-admin-service-test.yaml`
 - `zmbdp-portal-service-prd.yaml`
 

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -151,7 +151,7 @@ java -jar zmbdp-gateway.jar
 ```bash
 # 配置 SkyWalking Agent
 java -javaagent:/path/to/skywalking-agent.jar \
-     -Dskywalking.agent.service_name=zmbdp-gateway-service \
+     -Dskywalking.agent.service_name=zmbdp-gateway \
      -Dskywalking.collector.backend_service=skywalking-oap:11800 \
      -jar zmbdp-gateway.jar
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
     <artifactId>frameworkjava</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-
     <packaging>pom</packaging>
 
     <modules>
@@ -53,20 +52,31 @@
         <skywalking.version>9.0.0</skywalking.version>
         <xxl-job.version>2.4.2</xxl-job.version>
 
-        <!--运行环境-->
-        <runenv>dev</runenv>
-        <java.opts.default>-Xmx256m</java.opts.default>
-
-        <!--系统配置中心-->
+        <!--测试环境-->
+        <runenv>test</runenv>
+        <java.opts.default>-Xmx256m -javaagent:/opt/skywalking/agent/skywalking-agent.jar
+            -Dskywalking.agent.service_name=${project.artifactId}
+            -Dskywalking.collector.backend_service=frameworkjava-skywalking-oap:11800
+        </java.opts.default>
         <nacos.addr>http://你的云服务器内网ip/你的虚拟机内网ip:8848</nacos.addr>
+        <docker.skip.push>false</docker.skip.push>
+
+        <!--生产环境-->
+<!--        <runenv>prd</runenv>-->
+<!--        <java.opts.default>-Xmx256m -javaagent:/opt/skywalking/agent/skywalking-agent.jar-->
+<!--            -Dskywalking.agent.service_name=${project.artifactId}-->
+<!--            -Dskywalking.collector.backend_service=frameworkjava-skywalking-oap:11800-->
+<!--        </java.opts.default>-->
+<!--        <nacos.addr>http://你的云服务器1内网ip/你的虚拟机1内网ip:8854,http://你的云服务器1内网ip/你的虚拟机1内网ip:8856,http://你的云服务器2内网ip/你的虚拟机2内网ip:8858</nacos.addr>-->
+<!--        <docker.skip.push>false</docker.skip.push>-->
+
 
         <!--docker部署配置-->
         <dockerhost.addr>tcp://你的云服务器外网ip/你的虚拟机外网ip:2376</dockerhost.addr>
-        <dockerregistry.url>registry.cn-chengdu.aliyuncs.com</dockerregistry.url>
-        <dockerregistry.username>houyj1987@163.com</dockerregistry.username>
-        <dockerregistry.password>admin@666777</dockerregistry.password>
-        <dockerregistry.namespace>frameworkjava</dockerregistry.namespace>
-        <docker.skip.push>true</docker.skip.push>
+        <dockerregistry.url>crpi-otuh3k08p4yxr3tv.cn-shanghai.personal.cr.aliyuncs.com</dockerregistry.url>
+        <dockerregistry.username>${env.DOCKER_USERNAME}</dockerregistry.username>
+        <dockerregistry.password>${env.DOCKER_PASSWORD}</dockerregistry.password>
+        <dockerregistry.namespace>${env.DOCKER_NAMESPACE}</dockerregistry.namespace>
 
     </properties>
 

--- a/zmbdp-admin/zmbdp-admin-service/Dockerfile
+++ b/zmbdp-admin/zmbdp-admin-service/Dockerfile
@@ -1,7 +1,7 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jre
 ENV TZ=Asia/Shanghai
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 WORKDIR /workspace
-MAINTAINER JavaFH@163.com
+LABEL maintainer="JavaFH@163.com"
 COPY target/*.jar /workspace/app.jar
-ENTRYPOINT exec java $JAVA_OPTS -jar app.jar
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/zmbdp-admin/zmbdp-admin-service/pom.xml
+++ b/zmbdp-admin/zmbdp-admin-service/pom.xml
@@ -176,6 +176,11 @@
                                     <RUN_ENV>${runenv}</RUN_ENV>
                                     <JAVA_OPTS>${java.opts.default}</JAVA_OPTS>
                                 </env>
+                                <volumes>
+                                    <bind>
+                                        /opt/framework/deploy/skywalking/apache-skywalking-java-agent-9.5.0:/opt/skywalking/agent
+                                    </bind>
+                                </volumes>
                             </run>
                         </image>
                     </images>

--- a/zmbdp-file/zmbdp-file-service/Dockerfile
+++ b/zmbdp-file/zmbdp-file-service/Dockerfile
@@ -1,7 +1,7 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jre
 ENV TZ=Asia/Shanghai
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 WORKDIR /workspace
-MAINTAINER JavaFH@163.com
+LABEL maintainer="JavaFH@163.com"
 COPY target/*.jar /workspace/app.jar
-ENTRYPOINT exec java $JAVA_OPTS -jar app.jar
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/zmbdp-file/zmbdp-file-service/pom.xml
+++ b/zmbdp-file/zmbdp-file-service/pom.xml
@@ -143,6 +143,11 @@
                                     <RUN_ENV>${runenv}</RUN_ENV>
                                     <JAVA_OPTS>${java.opts.default}</JAVA_OPTS>
                                 </env>
+                                <volumes>
+                                    <bind>
+                                        /opt/framework/deploy/skywalking/apache-skywalking-java-agent-9.5.0:/opt/skywalking/agent
+                                    </bind>
+                                </volumes>
                             </run>
                         </image>
                     </images>

--- a/zmbdp-gateway/Dockerfile
+++ b/zmbdp-gateway/Dockerfile
@@ -1,7 +1,7 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jre
 ENV TZ=Asia/Shanghai
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 WORKDIR /workspace
-MAINTAINER JavaFH@163.com
+LABEL maintainer="JavaFH@163.com"
 COPY target/*.jar /workspace/app.jar
-ENTRYPOINT exec java $JAVA_OPTS -jar app.jar
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/zmbdp-gateway/pom.xml
+++ b/zmbdp-gateway/pom.xml
@@ -143,6 +143,11 @@
                                     <RUN_ENV>${runenv}</RUN_ENV>
                                     <JAVA_OPTS>${java.opts.default}</JAVA_OPTS>
                                 </env>
+                                <volumes>
+                                    <bind>
+                                        /opt/framework/deploy/skywalking/apache-skywalking-java-agent-9.5.0:/opt/skywalking/agent
+                                    </bind>
+                                </volumes>
                             </run>
                         </image>
                     </images>

--- a/zmbdp-gateway/src/main/java/com/zmbdp/gateway/filter/AuthFilter.java
+++ b/zmbdp-gateway/src/main/java/com/zmbdp/gateway/filter/AuthFilter.java
@@ -86,7 +86,6 @@ public class AuthFilter implements GlobalFilter, Ordered {
             return unauthorizedResponse(exchange, ResultCode.TOKEN_INVALID);
         }
         String userKey = JwtUtil.getUserKey(claims);
-//        String userKey = JwtUtil.getUserKey(token, secret);
         if (!redisService.hasKey(getTokenKey(userKey))) {
             // 拿到令牌，但是用户信息为空，说明令牌已过期
             return unauthorizedResponse(exchange, ResultCode.LOGIN_STATUS_OVERTIME);

--- a/zmbdp-mstemplate/zmbdp-mstemplate-service/Dockerfile
+++ b/zmbdp-mstemplate/zmbdp-mstemplate-service/Dockerfile
@@ -1,7 +1,7 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jre
 ENV TZ=Asia/Shanghai
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 WORKDIR /workspace
-MAINTAINER JavaFH@163.com
+LABEL maintainer="JavaFH@163.com"
 COPY target/*.jar /workspace/app.jar
-ENTRYPOINT exec java $JAVA_OPTS -jar app.jar
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/zmbdp-portal/zmbdp-portal-service/Dockerfile
+++ b/zmbdp-portal/zmbdp-portal-service/Dockerfile
@@ -1,7 +1,7 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jre
 ENV TZ=Asia/Shanghai
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 WORKDIR /workspace
-MAINTAINER JavaFH@163.com
+LABEL maintainer="JavaFH@163.com"
 COPY target/*.jar /workspace/app.jar
-ENTRYPOINT exec java $JAVA_OPTS -jar app.jar
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/zmbdp-portal/zmbdp-portal-service/pom.xml
+++ b/zmbdp-portal/zmbdp-portal-service/pom.xml
@@ -169,6 +169,11 @@
                                     <RUN_ENV>${runenv}</RUN_ENV>
                                     <JAVA_OPTS>${java.opts.default}</JAVA_OPTS>
                                 </env>
+                                <volumes>
+                                    <bind>
+                                        /opt/framework/deploy/skywalking/apache-skywalking-java-agent-9.5.0:/opt/skywalking/agent
+                                    </bind>
+                                </volumes>
                             </run>
                         </image>
                     </images>


### PR DESCRIPTION
- 修改服务名称格式，从 {服务名}-service-{环境} 改为 {服务名}-{环境}
- 将 Docker 基础镜像从 openjdk:17 更换为 eclipse-temurin:17-jre
- 将 MAINTAINER 指令替换为 LABEL maintainer 标签
- 更新 ENTRYPOINT 语法以支持更安全的执行方式
- 在 pom.xml 中添加 SkyWalking 探针挂载卷配置
- 移除 AuthFilter.java 中的注释代码
- 更新项目默认运行环境为测试环境并配置 SkyWalking 参数
- 更新 Docker registry 配置使用环境变量和新的仓库地址