### PR TITLE
refactor(message): 统一验证码发送开关配置及变量命名

### DIFF
--- a/zmbdp-common/zmbdp-common-message/src/main/java/com/zmbdp/common/message/service/CaptchaService.java
+++ b/zmbdp-common/zmbdp-common-message/src/main/java/com/zmbdp/common/message/service/CaptchaService.java
@@ -112,8 +112,8 @@ public class CaptchaService {
      *     <li>false：不发送验证码，使用固定验证码</li>
      * </ul>
      */
-    @Value("${captcha.send-message:true}")
-    private boolean sendMessage;
+    @Value("${captcha.random.enabled:true}")
+    private boolean captchaRandomEnabled;
 
     /**
      * 判断生成什么难度的验证码
@@ -132,13 +132,13 @@ public class CaptchaService {
      * 此配置对应 AliSmsServiceStrategy 的 sendMessage 配置。
      */
     @Value("${sms.send-message:false}")
-    private boolean smsSendMessage;
+    private boolean sendSmsMessage;
 
     /**
      * 邮件服务是否发送邮件（EmailCodeServiceStrategy 的 sendMessage 配置）
      */
     @Value("${mail.send-message:false}")
-    private boolean mailSendMessage;
+    private boolean sendMailMessage;
 
     /**
      * 验证码发送器路由器
@@ -205,12 +205,10 @@ public class CaptchaService {
                 : VerifyUtil.generateVerifyCode(MessageConstants.DEFAULT_CAPTCHA_LENGTH, captChaType);
 
         // 发送线上短信/邮件（根据账号格式自动选择发送器）
-        if (sendMessage) {
-            boolean result = captchaSenderRouter.sendCode(account, verifyCode);
-            // 发送失败时，如果使用了固定验证码，则不抛异常（允许失败）
-            if (!result && !shouldIgnoreSendFailure(account)) {
-                throw new ServiceException(ResultCode.SEND_MSG_FAILED);
-            }
+        boolean result = captchaSenderRouter.sendCode(account, verifyCode);
+        // 发送失败时，如果使用了固定验证码，则不抛异常（允许失败）
+        if (!result && !shouldIgnoreSendFailure(account)) {
+            throw new ServiceException(ResultCode.SEND_MSG_FAILED);
         }
         // 设置验证码的缓存
         redisService.setCacheObject(codeKey, verifyCode, accountCodeExpiration, TimeUnit.MINUTES);
@@ -334,15 +332,15 @@ public class CaptchaService {
      */
     private boolean shouldUseFixedCode(String account) {
         // 总开关关闭，使用固定验证码
-        if (!sendMessage) {
+        if (!captchaRandomEnabled) {
             return true;
         }
         // 用户输入的是手机号且短信通道关闭，使用固定验证码
-        if (VerifyUtil.checkPhone(account) && !smsSendMessage) {
+        if (VerifyUtil.checkPhone(account) && !sendSmsMessage) {
             return true;
         }
         // 用户输入的是邮箱且邮件通道关闭，使用固定验证码
-        return VerifyUtil.checkEmail(account) && !mailSendMessage;
+        return VerifyUtil.checkEmail(account) && !sendMailMessage;
     }
 
     /**

--- a/zmbdp-common/zmbdp-common-message/src/main/java/com/zmbdp/common/message/strategy/impl/AliSmsServiceStrategy.java
+++ b/zmbdp-common/zmbdp-common-message/src/main/java/com/zmbdp/common/message/strategy/impl/AliSmsServiceStrategy.java
@@ -110,7 +110,7 @@ public class AliSmsServiceStrategy implements ICaptchaSenderStrategy {
      * 此配置用于控制是否实际调用阿里云短信服务 API。
      */
     @Value("${sms.send-message:false}")
-    private boolean sendMessage;
+    private boolean sendSmsMessage;
 
     /**
      * 是否支持当前账号类型
@@ -205,7 +205,7 @@ public class AliSmsServiceStrategy implements ICaptchaSenderStrategy {
      */
     private boolean sendTemMessage(String phone, String templateCode, Map<String, String> params) {
         // 把是否发送线上短信交给 nacos 管理
-        if (!sendMessage) {
+        if (!sendSmsMessage) {
             log.error("短信发送通道关闭, {}", phone);
             return false;
         }

--- a/zmbdp-common/zmbdp-common-message/src/main/java/com/zmbdp/common/message/strategy/impl/EmailCodeServiceStrategy.java
+++ b/zmbdp-common/zmbdp-common-message/src/main/java/com/zmbdp/common/message/strategy/impl/EmailCodeServiceStrategy.java
@@ -116,8 +116,8 @@ public class EmailCodeServiceStrategy implements ICaptchaSenderStrategy {
      * 但作用域不同。<br>
      * 此配置仅控制邮件发送，不影响短信发送。
      */
-    @Value("${captcha.send-message:false}")
-    private boolean sendMessage;
+    @Value("${mail.send-message:false}")
+    private boolean sendMailMessage;
 
     /**
      * 是否支持当前账号类型
@@ -179,7 +179,7 @@ public class EmailCodeServiceStrategy implements ICaptchaSenderStrategy {
     public boolean sendCode(String email, String code) {
         log.info("开始发送邮件验证码, 账号: {}", email);
         // 把是否发送邮件交给 nacos 管理
-        if (!sendMessage) {
+        if (!sendMailMessage) {
             log.error("邮件发送通道关闭, {}", email);
             return false;
         }


### PR DESCRIPTION
- 将验证码随机开关配置由 captcha.send-message 修改为 captcha.random.enabled
- 统一短信发送开关变量命名为 sendSmsMessage，配置保持 sms.send-message
- 统一邮件发送开关变量命名为 sendMailMessage，配置保持 mail.send-message
- 调整验证码发送逻辑，移除旧的 sendMessage 条件判断
- 优化 AliSmsServiceStrategy 和 EmailCodeServiceStrategy 中发送开关判断逻辑和日志输出