### PR TITLE
refactor(config): 调整spring ansi输出配置位置

### DIFF
--- a/deploy/dev/res/sql/DEFAULT_GROUP/share-log-dev.yaml
+++ b/deploy/dev/res/sql/DEFAULT_GROUP/share-log-dev.yaml
@@ -1,3 +1,7 @@
+spring:
+  output:
+    ansi:
+      enabled: ALWAYS
 # 操作日志配置（支持 Nacos 热更新）
 log:
   # 全局开关，false 时关闭所有 @LogAction 日志记录

--- a/deploy/prd/vm1/res/sql/DEFAULT_GROUP/share-log-prd.yaml
+++ b/deploy/prd/vm1/res/sql/DEFAULT_GROUP/share-log-prd.yaml
@@ -1,3 +1,7 @@
+spring:
+  output:
+    ansi:
+      enabled: ALWAYS
 # 操作日志配置（支持 Nacos 热更新）
 log:
   # 全局开关，false 时关闭所有 @LogAction 日志记录

--- a/deploy/test/res/sql/nacos_config/DEFAULT_GROUP/share-log-test.yaml
+++ b/deploy/test/res/sql/nacos_config/DEFAULT_GROUP/share-log-test.yaml
@@ -1,3 +1,7 @@
+spring:
+  output:
+    ansi:
+      enabled: ALWAYS
 # 操作日志配置（支持 Nacos 热更新）
 log:
   # 全局开关，false 时关闭所有 @LogAction 日志记录

--- a/zmbdp-admin/zmbdp-admin-service/src/main/resources/bootstrap.yml
+++ b/zmbdp-admin/zmbdp-admin-service/src/main/resources/bootstrap.yml
@@ -1,7 +1,4 @@
 spring:
-  output:
-    ansi:
-      enabled: ALWAYS
   application:
     name: zmbdp-admin-service
   profiles:

--- a/zmbdp-file/zmbdp-file-service/src/main/resources/bootstrap.yml
+++ b/zmbdp-file/zmbdp-file-service/src/main/resources/bootstrap.yml
@@ -1,7 +1,4 @@
 spring:
-  output:
-    ansi:
-      enabled: ALWAYS
   application:
     name: zmbdp-file-service
   profiles:

--- a/zmbdp-gateway/src/main/resources/bootstrap.yml
+++ b/zmbdp-gateway/src/main/resources/bootstrap.yml
@@ -1,7 +1,4 @@
 spring:
-  output:
-    ansi:
-      enabled: ALWAYS
   application:
     name: zmbdp-gateway-service
   profiles:

--- a/zmbdp-mstemplate/zmbdp-mstemplate-service/src/main/resources/bootstrap.yml
+++ b/zmbdp-mstemplate/zmbdp-mstemplate-service/src/main/resources/bootstrap.yml
@@ -1,7 +1,4 @@
 spring:
-  output:
-    ansi:
-      enabled: ALWAYS
   application:
     name: zmbdp-mstemplate-service
   profiles:

--- a/zmbdp-portal/zmbdp-portal-service/src/main/resources/bootstrap.yml
+++ b/zmbdp-portal/zmbdp-portal-service/src/main/resources/bootstrap.yml
@@ -1,7 +1,4 @@
 spring:
-  output:
-    ansi:
-      enabled: ALWAYS
   application:
     name: zmbdp-portal-service
   profiles:


### PR DESCRIPTION
- 将spring output ansi enabled配置从各服务bootstrap.yml中移除
- 统一添加spring output ansi enabled配置到多个环境共享的yaml文件中
- 清理各服务配置文件，简化配置结构
- 保持操作日志配置及应用名配置不变